### PR TITLE
Re-enable pointer receivers

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -92,7 +92,7 @@ type {{{nickname}}}Opts struct {
 }
 
 {{/hasOptionalParams}}
-func (a {{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals *{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}*http.Response, error) {
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals *{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}*http.Response, error) {
 	var (
 		localVarHttpMethod   = http.Method{{httpMethod}}
 		localVarPostBody     interface{}

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -65,7 +65,7 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	// API Services
 {{#apis}}
 {{#operations}}
-	c.{{classname}} = ({{classname}}Service)(c.common)
+	c.{{classname}} = (*{{classname}}Service)(&c.common)
 {{/operations}}
 {{/apis}}
 {{/apiInfo}}


### PR DESCRIPTION
  - The original intent of pointer receivers was to allow the structs to be modified
  - Undoes part of the changes in 4cb1db2

4cb1db2 and bbc2ba4 together properly modified the client to use the interface instead of a pointer. However, I believer there was no need to make the implementations use value receivers instead of pointer receivers.The way go interfaces work, the client fields should be a regular type rather than a pointer, even though the implementing methods use pointer receivers to allow mutation of the implementation struct.
Ref: https://medium.com/@saiyerram/go-interfaces-pointers-4d1d98d5c9c6

Prior to this changes, `make mock` in mds-sdk-go required further manual changes to convert the generated pointer receivers to value receivers. With this change, `make mock` should now be completely automated.