### PR TITLE
Allow retrieving the underlying configuration for APIClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -159,6 +159,11 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Allow modification of underlying config for alternate implementations and testing
+func (c *APIClient) GetConfig() *Configuration {
+	return c.cfg
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,


### PR DESCRIPTION
  - Needed for dynamically changing the underlying implementations and for testing
